### PR TITLE
Expose functions to clear the bound caches

### DIFF
--- a/lib/src/main/java/ca/barrenechea/widget/recyclerview/decoration/DoubleHeaderDecoration.java
+++ b/lib/src/main/java/ca/barrenechea/widget/recyclerview/decoration/DoubleHeaderDecoration.java
@@ -44,6 +44,19 @@ public class DoubleHeaderDecoration extends RecyclerView.ItemDecoration {
         mHeaderCache = new HashMap<>();
     }
 
+    public void clearDoubleHeaderCache() {
+        clearSubHeaderCache();
+        clearHeaderCache();
+    }
+
+    public void clearSubHeaderCache() {
+        mSubHeaderCache.clear();
+    }
+
+    public void clearHeaderCache() {
+        mHeaderCache.clear();
+    }
+
     private RecyclerView.ViewHolder getSubHeader(RecyclerView parent, int position) {
         final long key = mAdapter.getSubHeaderId(position);
 

--- a/lib/src/main/java/ca/barrenechea/widget/recyclerview/decoration/StickyHeaderDecoration.java
+++ b/lib/src/main/java/ca/barrenechea/widget/recyclerview/decoration/StickyHeaderDecoration.java
@@ -58,6 +58,10 @@ public class StickyHeaderDecoration extends RecyclerView.ItemDecoration {
         outRect.set(0, headerHeight, 0, 0);
     }
 
+    public void clearHeaderCache() {
+        mHeaderCache.clear();
+    }
+
     private boolean hasHeader(int position) {
         if (position == 0) {
             return true;

--- a/sample/src/main/java/ca/barrenechea/stickyheaders/ui/DoubleHeaderFragment.java
+++ b/sample/src/main/java/ca/barrenechea/stickyheaders/ui/DoubleHeaderFragment.java
@@ -17,17 +17,33 @@
 package ca.barrenechea.stickyheaders.ui;
 
 import android.support.v7.widget.RecyclerView;
+import android.view.MenuItem;
 
+import ca.barrenechea.stickyheaders.R;
 import ca.barrenechea.stickyheaders.widget.DoubleHeaderTestAdapter;
 import ca.barrenechea.widget.recyclerview.decoration.DoubleHeaderDecoration;
 
 public class DoubleHeaderFragment extends BaseDecorationFragment {
 
+    private DoubleHeaderDecoration decor;
+
     @Override
     protected void setAdapterAndDecor(RecyclerView list) {
         final DoubleHeaderTestAdapter adapter = new DoubleHeaderTestAdapter(this.getActivity());
+        decor = new DoubleHeaderDecoration(adapter);
 
         list.setAdapter(adapter);
-        list.addItemDecoration(new DoubleHeaderDecoration(adapter), 1);
+        list.addItemDecoration(decor, 1);
     }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == R.id.action_clear_cache) {
+            decor.clearDoubleHeaderCache();
+            return true;
+        }
+
+        return super.onOptionsItemSelected(item);
+    }
+
 }

--- a/sample/src/main/java/ca/barrenechea/stickyheaders/ui/DoubleHeaderFragment.java
+++ b/sample/src/main/java/ca/barrenechea/stickyheaders/ui/DoubleHeaderFragment.java
@@ -31,6 +31,7 @@ public class DoubleHeaderFragment extends BaseDecorationFragment {
     protected void setAdapterAndDecor(RecyclerView list) {
         final DoubleHeaderTestAdapter adapter = new DoubleHeaderTestAdapter(this.getActivity());
         decor = new DoubleHeaderDecoration(adapter);
+        setHasOptionsMenu(true);
 
         list.setAdapter(adapter);
         list.addItemDecoration(decor, 1);

--- a/sample/src/main/java/ca/barrenechea/stickyheaders/ui/StickyHeaderFragment.java
+++ b/sample/src/main/java/ca/barrenechea/stickyheaders/ui/StickyHeaderFragment.java
@@ -17,17 +17,33 @@
 package ca.barrenechea.stickyheaders.ui;
 
 import android.support.v7.widget.RecyclerView;
+import android.view.MenuItem;
 
+import ca.barrenechea.stickyheaders.R;
 import ca.barrenechea.stickyheaders.widget.StickyTestAdapter;
 import ca.barrenechea.widget.recyclerview.decoration.StickyHeaderDecoration;
 
 public class StickyHeaderFragment extends BaseDecorationFragment {
 
+    private StickyHeaderDecoration decor;
+
     @Override
     protected void setAdapterAndDecor(RecyclerView list) {
         final StickyTestAdapter adapter = new StickyTestAdapter(this.getActivity());
+        decor = new StickyHeaderDecoration(adapter);
 
         list.setAdapter(adapter);
-        list.addItemDecoration(new StickyHeaderDecoration(adapter), 1);
+        list.addItemDecoration(decor, 1);
     }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == R.id.action_clear_cache) {
+            decor.clearHeaderCache();
+            return true;
+        }
+
+        return super.onOptionsItemSelected(item);
+    }
+
 }

--- a/sample/src/main/java/ca/barrenechea/stickyheaders/ui/StickyHeaderFragment.java
+++ b/sample/src/main/java/ca/barrenechea/stickyheaders/ui/StickyHeaderFragment.java
@@ -31,6 +31,7 @@ public class StickyHeaderFragment extends BaseDecorationFragment {
     protected void setAdapterAndDecor(RecyclerView list) {
         final StickyTestAdapter adapter = new StickyTestAdapter(this.getActivity());
         decor = new StickyHeaderDecoration(adapter);
+        setHasOptionsMenu(true);
 
         list.setAdapter(adapter);
         list.addItemDecoration(decor, 1);

--- a/sample/src/main/res/menu/activity_main.xml
+++ b/sample/src/main/res/menu/activity_main.xml
@@ -21,4 +21,8 @@
         android:id="@+id/action_about"
         android:showAsAction="never"
         android:title="@string/about"/>
+
+    <item android:id="@+id/action_clear_cache"
+        android:title="Clear Cache"
+        android:showAsAction="ifRoom"/>
 </menu>


### PR DESCRIPTION
In some cases the header(s) may need be re-drawn so a function to clear their caches should be created and provided to developers.