### PR TITLE
Prevent calls to adapter with invalid item index from getHeaderTop, and take animation into account.

### DIFF
--- a/lib/src/main/java/ca/barrenechea/widget/recyclerview/decoration/StickyHeaderDecoration.java
+++ b/lib/src/main/java/ca/barrenechea/widget/recyclerview/decoration/StickyHeaderDecoration.java
@@ -129,7 +129,7 @@ public class StickyHeaderDecoration extends RecyclerView.ItemDecoration {
     }
 
     private int getHeaderTop(RecyclerView parent, View child, View header, int adapterPos, int layoutPos) {
-        int top = child.getTop() - header.getHeight();
+        int top = getAnimatedTop(child) - header.getHeight();
         if (layoutPos == 0) {
             final int count = parent.getChildCount();
             final long currentId = mAdapter.getHeaderId(adapterPos);
@@ -140,7 +140,7 @@ public class StickyHeaderDecoration extends RecyclerView.ItemDecoration {
                     long nextId = mAdapter.getHeaderId(adapterPosHere);
                     if (nextId != currentId) {
                         final View next = parent.getChildAt(i);
-                        final int offset = next.getTop() - (header.getHeight() + getHeader(parent, i).itemView.getHeight());
+                        final int offset = getAnimatedTop(next) - (header.getHeight() + getHeader(parent, i).itemView.getHeight());
                         if (offset < 0) {
                             return offset;
                         } else {
@@ -156,4 +156,7 @@ public class StickyHeaderDecoration extends RecyclerView.ItemDecoration {
         return top;
     }
 
+    private int getAnimatedTop(View child) {
+        return child.getTop() + (int)child.getTranslationY();
+    }
 }

--- a/lib/src/main/java/ca/barrenechea/widget/recyclerview/decoration/StickyHeaderDecoration.java
+++ b/lib/src/main/java/ca/barrenechea/widget/recyclerview/decoration/StickyHeaderDecoration.java
@@ -135,14 +135,18 @@ public class StickyHeaderDecoration extends RecyclerView.ItemDecoration {
             final long currentId = mAdapter.getHeaderId(adapterPos);
             // find next view with header and compute the offscreen push if needed
             for (int i = 1; i < count; i++) {
-                long nextId = mAdapter.getHeaderId(adapterPos + i);
-                if (nextId != currentId) {
-                    final View next = parent.getChildAt(i);
-                    final int offset = next.getTop() - (header.getHeight() + getHeader(parent, i).itemView.getHeight());
-                    if (offset < 0) {
-                        return offset;
-                    } else {
-                        break;
+                int layoutPosHere = layoutPos + i;
+                int adapterPosHere = parent.getChildAdapterPosition(parent.getChildAt(layoutPosHere));
+                if (adapterPosHere != RecyclerView.NO_POSITION) {
+                    long nextId = mAdapter.getHeaderId(adapterPosHere);
+                    if (nextId != currentId) {
+                        final View next = parent.getChildAt(i);
+                        final int offset = next.getTop() - (header.getHeight() + getHeader(parent, i).itemView.getHeight());
+                        if (offset < 0) {
+                            return offset;
+                        } else {
+                            break;
+                        }
                     }
                 }
             }

--- a/lib/src/main/java/ca/barrenechea/widget/recyclerview/decoration/StickyHeaderDecoration.java
+++ b/lib/src/main/java/ca/barrenechea/widget/recyclerview/decoration/StickyHeaderDecoration.java
@@ -135,8 +135,7 @@ public class StickyHeaderDecoration extends RecyclerView.ItemDecoration {
             final long currentId = mAdapter.getHeaderId(adapterPos);
             // find next view with header and compute the offscreen push if needed
             for (int i = 1; i < count; i++) {
-                int layoutPosHere = layoutPos + i;
-                int adapterPosHere = parent.getChildAdapterPosition(parent.getChildAt(layoutPosHere));
+                int adapterPosHere = parent.getChildAdapterPosition(parent.getChildAt(i));
                 if (adapterPosHere != RecyclerView.NO_POSITION) {
                     long nextId = mAdapter.getHeaderId(adapterPosHere);
                     if (nextId != currentId) {


### PR DESCRIPTION
Tip: If you add the query param "w=0" to the url when viewing this pull request, you can ignore whitespace changes, which will make the changes I actually made clear.