### PR TITLE
Smooth scrolling support etc. for DoubleHeaderDecoration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,8 +17,8 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-VERSION_NAME=0.2.4
-VERSION_CODE=5
+VERSION_NAME=0.2.5
+VERSION_CODE=6
 GROUP=ca.barrenechea.header-decor
 
 POM_DESCRIPTION=Sticky recycler view header decorations for android.

--- a/lib/src/main/java/ca/barrenechea/widget/recyclerview/decoration/DoubleHeaderDecoration.java
+++ b/lib/src/main/java/ca/barrenechea/widget/recyclerview/decoration/DoubleHeaderDecoration.java
@@ -29,8 +29,6 @@ import java.util.Map;
  * A double sticky header decoration for android's RecyclerView.
  */
 public class DoubleHeaderDecoration extends RecyclerView.ItemDecoration {
-    private static final String TAG = DoubleHeaderDecoration.class.getName();
-
     private DoubleHeaderAdapter mAdapter;
     private Map<Long, RecyclerView.ViewHolder> mSubHeaderCache;
     private Map<Long, RecyclerView.ViewHolder> mHeaderCache;

--- a/lib/src/main/java/ca/barrenechea/widget/recyclerview/decoration/DoubleHeaderDecoration.java
+++ b/lib/src/main/java/ca/barrenechea/widget/recyclerview/decoration/DoubleHeaderDecoration.java
@@ -19,8 +19,6 @@ package ca.barrenechea.widget.recyclerview.decoration;
 import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.support.v7.widget.RecyclerView;
-import android.text.TextUtils;
-import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -36,8 +34,6 @@ public class DoubleHeaderDecoration extends RecyclerView.ItemDecoration {
     private DoubleHeaderAdapter mAdapter;
     private Map<Long, RecyclerView.ViewHolder> mSubHeaderCache;
     private Map<Long, RecyclerView.ViewHolder> mHeaderCache;
-    private String lastLog = "";
-    private String lastHeaderLog = "";
 
     /**
      * @param adapter the double header adapter to use
@@ -168,28 +164,8 @@ public class DoubleHeaderDecoration extends RecyclerView.ItemDecoration {
      */
     @Override
     public void onDrawOver(Canvas c, RecyclerView parent, RecyclerView.State state) {
-        StringBuilder log = new StringBuilder();
-        for (int layoutPos = 0; layoutPos < parent.getChildCount(); layoutPos++) {
-            View child = parent.getChildAt(layoutPos);
-            int adapterPos = parent.getChildAdapterPosition(child);
-            boolean visible = getAnimatedTop(child) > (-child.getHeight()) && getAnimatedTop(child) < parent.getHeight();
-            log.append(
-                    ""
-                    + (visible ? "" : "(")
-                    + layoutPos + "=>"
-                    + (adapterPos == RecyclerView.NO_POSITION ? "X" : adapterPos)
-                    + (visible ? "" : ")")
-                    + " | ");
-        }
-        String newLog = log.toString();
-        if (!TextUtils.equals(newLog, lastLog)) {
-            Log.i(TAG, newLog);
-            lastLog = newLog;
-        }
-
         final int count = parent.getChildCount();
 
-        StringBuilder headerLog = new StringBuilder();
         boolean headerDrawn = false;
         for (int layoutPos = 0; layoutPos < count; layoutPos++) {
             final View child = parent.getChildAt(layoutPos);
@@ -197,8 +173,7 @@ public class DoubleHeaderDecoration extends RecyclerView.ItemDecoration {
             final int adapterPos = parent.getChildAdapterPosition(child);
             if (visible && adapterPos != RecyclerView.NO_POSITION && (!headerDrawn || hasSubHeader(adapterPos))) {
                 int left, top;
-                RecyclerView.ViewHolder headerHolder = getHeader(parent, adapterPos);
-                final View header = headerHolder.itemView;
+                final View header = getHeader(parent, adapterPos).itemView;
                 final View subHeader = getSubHeader(parent, adapterPos).itemView;
 
                 c.save();
@@ -213,18 +188,12 @@ public class DoubleHeaderDecoration extends RecyclerView.ItemDecoration {
                     left = child.getLeft();
                     top = getHeaderTop(parent, child, subHeader, header, adapterPos, layoutPos);
                     c.translate(left, top);
-                    headerLog.append("\"" + headerHolder + "\"@(" + left + ", " + top + ") | ");
                     header.draw(c);
                     c.restore();
                 }
 
                 headerDrawn = true;
             }
-        }
-        final String newHeaderLog = headerLog.toString();
-        if (!TextUtils.equals(newHeaderLog, lastHeaderLog)) {
-            Log.i(TAG, newHeaderLog);
-            lastHeaderLog = newHeaderLog;
         }
     }
 
@@ -299,7 +268,7 @@ public class DoubleHeaderDecoration extends RecyclerView.ItemDecoration {
         for (int otherLayoutPos = layoutPos - 1; otherLayoutPos >= 0; --otherLayoutPos) {
             final View otherChild = parent.getChildAt(otherLayoutPos);
             if (parent.getChildAdapterPosition(otherChild) != RecyclerView.NO_POSITION) {
-                boolean visible = getAnimatedTop(otherChild) > -otherChild.getHeight()/* && child.getTop() < parent.getHeight()*/;
+                boolean visible = getAnimatedTop(otherChild) > -otherChild.getHeight();
                 if (visible) {
                     isFirstValidChild = false;
                     break;

--- a/lib/src/main/java/ca/barrenechea/widget/recyclerview/decoration/DoubleHeaderDecoration.java
+++ b/lib/src/main/java/ca/barrenechea/widget/recyclerview/decoration/DoubleHeaderDecoration.java
@@ -19,6 +19,8 @@ package ca.barrenechea.widget.recyclerview.decoration;
 import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.support.v7.widget.RecyclerView;
+import android.text.TextUtils;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -29,10 +31,13 @@ import java.util.Map;
  * A double sticky header decoration for android's RecyclerView.
  */
 public class DoubleHeaderDecoration extends RecyclerView.ItemDecoration {
+    private static final String TAG = DoubleHeaderDecoration.class.getName();
 
     private DoubleHeaderAdapter mAdapter;
     private Map<Long, RecyclerView.ViewHolder> mSubHeaderCache;
     private Map<Long, RecyclerView.ViewHolder> mHeaderCache;
+    private String lastLog = "";
+    private String lastHeaderLog = "";
 
     /**
      * @param adapter the double header adapter to use
@@ -163,16 +168,37 @@ public class DoubleHeaderDecoration extends RecyclerView.ItemDecoration {
      */
     @Override
     public void onDrawOver(Canvas c, RecyclerView parent, RecyclerView.State state) {
+        StringBuilder log = new StringBuilder();
+        for (int layoutPos = 0; layoutPos < parent.getChildCount(); layoutPos++) {
+            View child = parent.getChildAt(layoutPos);
+            int adapterPos = parent.getChildAdapterPosition(child);
+            boolean visible = getAnimatedTop(child) > (-child.getHeight()) && getAnimatedTop(child) < parent.getHeight();
+            log.append(
+                    ""
+                    + (visible ? "" : "(")
+                    + layoutPos + "=>"
+                    + (adapterPos == RecyclerView.NO_POSITION ? "X" : adapterPos)
+                    + (visible ? "" : ")")
+                    + " | ");
+        }
+        String newLog = log.toString();
+        if (!TextUtils.equals(newLog, lastLog)) {
+            Log.i(TAG, newLog);
+            lastLog = newLog;
+        }
+
         final int count = parent.getChildCount();
 
+        StringBuilder headerLog = new StringBuilder();
+        boolean headerDrawn = false;
         for (int layoutPos = 0; layoutPos < count; layoutPos++) {
             final View child = parent.getChildAt(layoutPos);
-
+            boolean visible = getAnimatedTop(child) > -child.getHeight()/* && child.getTop() < parent.getHeight()*/;
             final int adapterPos = parent.getChildAdapterPosition(child);
-
-            if (adapterPos != RecyclerView.NO_POSITION && (layoutPos == 0 || hasSubHeader(adapterPos))) {
+            if (visible && adapterPos != RecyclerView.NO_POSITION && (!headerDrawn || hasSubHeader(adapterPos))) {
                 int left, top;
-                final View header = getHeader(parent, adapterPos).itemView;
+                RecyclerView.ViewHolder headerHolder = getHeader(parent, adapterPos);
+                final View header = headerHolder.itemView;
                 final View subHeader = getSubHeader(parent, adapterPos).itemView;
 
                 c.save();
@@ -182,42 +208,53 @@ public class DoubleHeaderDecoration extends RecyclerView.ItemDecoration {
                 subHeader.draw(c);
                 c.restore();
 
-                if (layoutPos == 0 || hasHeader(adapterPos)) {
+                if (!headerDrawn || hasHeader(adapterPos)) {
                     c.save();
                     left = child.getLeft();
                     top = getHeaderTop(parent, child, subHeader, header, adapterPos, layoutPos);
                     c.translate(left, top);
+                    headerLog.append("\"" + headerHolder + "\"@(" + left + ", " + top + ") | ");
                     header.draw(c);
                     c.restore();
                 }
+
+                headerDrawn = true;
             }
+        }
+        final String newHeaderLog = headerLog.toString();
+        if (!TextUtils.equals(newHeaderLog, lastHeaderLog)) {
+            Log.i(TAG, newHeaderLog);
+            lastHeaderLog = newHeaderLog;
         }
     }
 
     private int getSubHeaderTop(RecyclerView parent, View child, View header, View subHeader, int adapterPos, int layoutPos) {
-        int top = child.getTop() - subHeader.getHeight();
-        if (layoutPos == 0) {
+        int top = getAnimatedTop(child) - subHeader.getHeight();
+        if (isFirstValidChild(layoutPos, parent)) {
             final int count = parent.getChildCount();
             final long currentHeaderId = mAdapter.getHeaderId(adapterPos);
             final long currentSubHeaderId = mAdapter.getSubHeaderId(adapterPos);
 
             // find next view with sub-header and compute the offscreen push if needed
-            for (int i = 1; i < count; i++) {
+            for (int i = layoutPos + 1; i < count; i++) {
                 final View next = parent.getChildAt(i);
-                final long nextHeaderId = mAdapter.getHeaderId(adapterPos + i);
-                final long nextSubHeaderId = mAdapter.getSubHeaderId(adapterPos + i);
+                int adapterPosHere = parent.getChildAdapterPosition(next);
+                if (adapterPosHere != RecyclerView.NO_POSITION) {
+                    final long nextHeaderId = mAdapter.getHeaderId(adapterPosHere);
+                    final long nextSubHeaderId = mAdapter.getSubHeaderId(adapterPosHere);
 
-                if ((nextSubHeaderId != currentSubHeaderId)) {
-                    int headersHeight = subHeader.getHeight() + getSubHeader(parent, i).itemView.getHeight();
-                    if (nextHeaderId != currentHeaderId) {
-                        headersHeight += getHeader(parent, i).itemView.getHeight();
-                    }
+                    if ((nextSubHeaderId != currentSubHeaderId)) {
+                        int headersHeight = subHeader.getHeight() + getSubHeader(parent, adapterPosHere).itemView.getHeight();
+                        if (nextHeaderId != currentHeaderId) {
+                            headersHeight += getHeader(parent, adapterPosHere).itemView.getHeight();
+                        }
 
-                    final int offset = next.getTop() - headersHeight;
-                    if (offset < header.getHeight()) {
-                        return offset;
-                    } else {
-                        break;
+                        final int offset = getAnimatedTop(next) - headersHeight;
+                        if (offset < header.getHeight()) {
+                            return offset;
+                        } else {
+                            break;
+                        }
                     }
                 }
             }
@@ -227,24 +264,26 @@ public class DoubleHeaderDecoration extends RecyclerView.ItemDecoration {
     }
 
     private int getHeaderTop(RecyclerView parent, View child, View header, View subHeader, int adapterPos, int layoutPos) {
-        int top = child.getTop() - header.getHeight() - subHeader.getHeight();
-        if (layoutPos == 0) {
+        int top = getAnimatedTop(child) - header.getHeight() - subHeader.getHeight();
+        if (isFirstValidChild(layoutPos, parent)) {
             final int count = parent.getChildCount();
             final long currentId = mAdapter.getHeaderId(adapterPos);
 
             // find next view with header and compute the offscreen push if needed
-            for (int i = 1; i < count; i++) {
-                long nextId = mAdapter.getHeaderId(adapterPos + i);
+            for (int i = layoutPos + 1; i < count; i++) {
+                View next = parent.getChildAt(i);
+                int adapterPosHere = parent.getChildAdapterPosition(next);
+                if (adapterPosHere != RecyclerView.NO_POSITION) {
+                    long nextId = mAdapter.getHeaderId(adapterPosHere);
+                    if (nextId != currentId) {
+                        final int headersHeight = header.getHeight() + getHeader(parent, adapterPosHere).itemView.getHeight();
+                        final int offset = getAnimatedTop(next) - headersHeight - subHeader.getHeight();
 
-                if (nextId != currentId) {
-                    final View next = parent.getChildAt(i);
-                    final int headersHeight = header.getHeight() + getHeader(parent, i).itemView.getHeight();
-                    final int offset = next.getTop() - headersHeight - subHeader.getHeight();
-
-                    if (offset < 0) {
-                        return offset;
-                    } else {
-                        break;
+                        if (offset < 0) {
+                            return offset;
+                        } else {
+                            break;
+                        }
                     }
                 }
             }
@@ -253,5 +292,24 @@ public class DoubleHeaderDecoration extends RecyclerView.ItemDecoration {
         }
 
         return top;
+    }
+
+    private boolean isFirstValidChild(int layoutPos, RecyclerView parent) {
+        boolean isFirstValidChild = true;
+        for (int otherLayoutPos = layoutPos - 1; otherLayoutPos >= 0; --otherLayoutPos) {
+            final View otherChild = parent.getChildAt(otherLayoutPos);
+            if (parent.getChildAdapterPosition(otherChild) != RecyclerView.NO_POSITION) {
+                boolean visible = getAnimatedTop(otherChild) > -otherChild.getHeight()/* && child.getTop() < parent.getHeight()*/;
+                if (visible) {
+                    isFirstValidChild = false;
+                    break;
+                }
+            }
+        }
+        return isFirstValidChild;
+    }
+
+    private int getAnimatedTop(View child) {
+        return child.getTop() + (int)child.getTranslationY();
     }
 }

--- a/lib/src/main/java/ca/barrenechea/widget/recyclerview/decoration/StickyHeaderDecoration.java
+++ b/lib/src/main/java/ca/barrenechea/widget/recyclerview/decoration/StickyHeaderDecoration.java
@@ -140,7 +140,7 @@ public class StickyHeaderDecoration extends RecyclerView.ItemDecoration {
                     long nextId = mAdapter.getHeaderId(adapterPosHere);
                     if (nextId != currentId) {
                         final View next = parent.getChildAt(i);
-                        final int offset = getAnimatedTop(next) - (header.getHeight() + getHeader(parent, i).itemView.getHeight());
+                        final int offset = getAnimatedTop(next) - (header.getHeight() + getHeader(parent, adapterPosHere).itemView.getHeight());
                         if (offset < 0) {
                             return offset;
                         } else {


### PR DESCRIPTION
Porting some animation-related fixes from StickyHeaderDecoration to DoubleHeaderDecoration.
Additional fixes to DoubleHeaderDecoration to handle smooth scrolling (i.e. LinearLayoutManager.scrollToPositionWithOffset); mostly filtering-out invisible children off the top of the parent RecyclerView that exist in this situation.