### PR TITLE
Use getMeasuredWidth() and -Height() for measuring header

### DIFF
--- a/lib/src/main/java/ca/barrenechea/widget/recyclerview/decoration/StickyHeaderDecoration.java
+++ b/lib/src/main/java/ca/barrenechea/widget/recyclerview/decoration/StickyHeaderDecoration.java
@@ -133,8 +133,8 @@ public class StickyHeaderDecoration extends RecyclerView.ItemDecoration {
             //noinspection unchecked
             mAdapter.onBindHeaderViewHolder(holder, position);
 
-            int widthSpec = View.MeasureSpec.makeMeasureSpec(parent.getWidth(), View.MeasureSpec.EXACTLY);
-            int heightSpec = View.MeasureSpec.makeMeasureSpec(parent.getHeight(), View.MeasureSpec.UNSPECIFIED);
+            int widthSpec = View.MeasureSpec.makeMeasureSpec(parent.getMeasuredWidth(), View.MeasureSpec.EXACTLY);
+            int heightSpec = View.MeasureSpec.makeMeasureSpec(parent.getMeasuredHeight(), View.MeasureSpec.UNSPECIFIED);
 
             int childWidth = ViewGroup.getChildMeasureSpec(widthSpec,
                     parent.getPaddingLeft() + parent.getPaddingRight(), header.getLayoutParams().width);


### PR DESCRIPTION
The RecyclerView itself is sometimes not laid out properly, so getWidth() will return 0. Using getMeasuredWidth instead will return the proper size, so the headers will be laid out properly and show up. Fixes https://github.com/edubarr/header-decor/issues/45