### PR TITLE
Move dependency version numbers to a common location

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,23 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    ext.versions = [
+            'compileSdk'         : 27,
+            'minSdk'             : 15,
+            'targetSdk'          : 27,
+            'androidGradlePlugin': '3.1.2',
+            'supportLibrary'     : '27.1.1',
+            'bintrayRelease'     : '0.5.0',
+    ]
+
     repositories {
         jcenter()
         google()
     }
+
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
-        classpath 'com.novoda:bintray-release:0.2.7'
+        classpath "com.android.tools.build:gradle:${versions.androidGradlePlugin}"
+        classpath "com.novoda:bintray-release:${versions.bintrayRelease}"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -18,15 +18,15 @@ apply plugin: 'com.android.library'
 //apply plugin: 'bintray-release'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    compileSdkVersion versions.compileSdk
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 27
+        minSdkVersion versions.minSdk
+        targetSdkVersion versions.targetSdk
         versionCode Integer.parseInt(project.VERSION_CODE)
         versionName project.VERSION_NAME
     }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -36,8 +36,8 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:recyclerview-v7:27.1.1'
-    implementation 'com.android.support:support-annotations:27.1.1'
+    implementation "com.android.support:recyclerview-v7:${versions.supportLibrary}"
+    implementation "com.android.support:support-annotations:${versions.supportLibrary}"
 }
 
 apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -17,16 +17,16 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    compileSdkVersion versions.compileSdk
 
     defaultConfig {
         applicationId "ca.barrenechea.stickyheaders"
-        minSdkVersion 15
-        targetSdkVersion 27
+        minSdkVersion versions.minSdk
+        targetSdkVersion versions.targetSdk
         versionCode Integer.parseInt(project.VERSION_CODE)
         versionName project.VERSION_NAME
     }
+
     buildTypes {
         debug {
             applicationIdSuffix ".debug"
@@ -41,6 +41,6 @@ android {
 
 dependencies {
     implementation project(':lib')
-    implementation 'com.android.support:support-v4:27.1.1'
-    implementation 'com.android.support:recyclerview-v7:27.1.1'
+    implementation "com.android.support:support-v4:${versions.supportLibrary}"
+    implementation "com.android.support:recyclerview-v7:${versions.supportLibrary}"
 }


### PR DESCRIPTION
As discussed in https://github.com/edubarr/header-decor/pull/88#discussion_r188989905

* Remove unnecessary android.buildToolsVersion property
* Extract dependency version numbers to a common location